### PR TITLE
Packer increase clone timeout to 5min

### DIFF
--- a/lua/user/plugins.lua
+++ b/lua/user/plugins.lua
@@ -36,6 +36,9 @@ packer.init {
       return require("packer.util").float { border = "rounded" }
     end,
   },
+  git = {
+    clone_timeout = 300, -- Timeout, in seconds, for git clones
+  },
 }
 
 -- Install your plugins here


### PR DESCRIPTION
If the internet connection is not stable, default 60s won't suffice.

Recreated the PR https://github.com/LunarVim/nvim-basic-ide/pull/3