### PR TITLE
Change deprecated method in handles.lua

### DIFF
--- a/lua/user/lsp/handlers.lua
+++ b/lua/user/lsp/handlers.lua
@@ -69,11 +69,11 @@ M.on_attach = function(client, bufnr)
   end
 
   if client.name == "tsserver" then
-    client.resolved_capabilities.document_formatting = false
+    client.client_capabilities.document_formatting = false
   end
 
   if client.name == "sumneko_lua" then
-    client.resolved_capabilities.document_formatting = false
+    client.client_capabilities.document_formatting = false
   end
 
   M.capabilities = vim.lsp.protocol.make_client_capabilities()


### PR DESCRIPTION
Running vim gives the following error:
```
[LSP] Accessing client.resolved_capabilities is deprecated, update your plugins or configuration to access client.server_capabilities instead.The new key/value pairs in server_capabilities directly match those defined in the language server protocol  
```
This change fixes the error.