### PR TITLE
Telescope  - mapping <Esc> to quit in insert mode

### DIFF
--- a/lua/user/telescope.lua
+++ b/lua/user/telescope.lua
@@ -19,6 +19,7 @@ telescope.setup {
         ["<Up>"] = actions.cycle_history_prev,
         ["<C-j>"] = actions.move_selection_next,
         ["<C-k>"] = actions.move_selection_previous,
+        ["<Esc>"] = actions.close,
       },
     },
   },


### PR DESCRIPTION
This will make sure you don't need to press Esc twice if you want to close Telescope