### PR TITLE
Make LSP settings more easily configurable

### DIFF
--- a/lua/user/lsp/lsp-installer.lua
+++ b/lua/user/lsp/lsp-installer.lua
@@ -29,14 +29,9 @@ for _, server in pairs(servers) do
     capabilities = require("user.lsp.handlers").capabilities,
   }
 
-  if server == "sumneko_lua" then
-    local sumneko_opts = require "user.lsp.settings.sumneko_lua"
-    opts = vim.tbl_deep_extend("force", sumneko_opts, opts)
-  end
-
-  if server == "pyright" then
-    local pyright_opts = require "user.lsp.settings.pyright"
-    opts = vim.tbl_deep_extend("force", pyright_opts, opts)
+  local require_ok, conf_opts = pcall(require, "user.lsp.settings." .. server)
+  if require_ok then
+    opts = vim.tbl_deep_extend("force", conf_opts, opts)
   end
 
   lspconfig[server].setup(opts)


### PR DESCRIPTION
Instead of having to add a new block every time someone wants to configure an additional language server, this PR looks for LSP settings files for each language server and adds their settings to `opts` if they exist.