### PR TITLE
Move rust keybindings to seperate ftplugins file.

### DIFF
--- a/ftplugin/rust.lua
+++ b/ftplugin/rust.lua
@@ -1,0 +1,22 @@
+-- Rust specific keybindings
+local keymap = vim.keymap.set
+local key_opts = { silent = true }
+
+keymap("n", "<leader>rh", "<cmd>RustSetInlayHints<Cr>", key_opts)
+keymap("n", "<leader>rhd", "<cmd>RustDisableInlayHints<Cr>", key_opts)
+keymap("n", "<leader>th", "<cmd>RustToggleInlayHints<Cr>", key_opts)
+keymap("n", "<leader>rr", "<cmd>RustRunnables<Cr>", key_opts)
+keymap("n", "<leader>rem", "<cmd>RustExpandMacro<Cr>", key_opts)
+keymap("n", "<leader>roc", "<cmd>RustOpenCargo<Cr>", key_opts)
+keymap("n", "<leader>rpm", "<cmd>RustParentModule<Cr>", key_opts)
+keymap("n", "<leader>rjl", "<cmd>RustJoinLines<Cr>", key_opts)
+keymap("n", "<leader>rha", "<cmd>RustHoverActions<Cr>", key_opts)
+keymap("n", "<leader>rhr", "<cmd>RustHoverRange<Cr>", key_opts)
+keymap("n", "<leader>rmd", "<cmd>RustMoveItemDown<Cr>", key_opts)
+keymap("n", "<leader>rmu", "<cmd>RustMoveItemUp<Cr>", key_opts)
+keymap("n", "<leader>rsb", "<cmd>RustStartStandaloneServerForBuffer<Cr>", key_opts)
+keymap("n", "<leader>rd", "<cmd>RustDebuggables<Cr>", key_opts)
+keymap("n", "<leader>rv", "<cmd>RustViewCrateGraph<Cr>", key_opts)
+keymap("n", "<leader>rw", "<cmd>RustReloadWorkspace<Cr>", key_opts)
+keymap("n", "<leader>rss", "<cmd>RustSSR<Cr>", key_opts)
+keymap("n", "<leader>rxd", "<cmd>RustOpenExternalDocs<Cr>", key_opts)

--- a/lua/user/lsp/lsp-installer.lua
+++ b/lua/user/lsp/lsp-installer.lua
@@ -42,28 +42,6 @@ for _, server in pairs(servers) do
   end
 
   if server == "rust_analyzer" then
-    local keymap = vim.keymap.set
-    local key_opts = { silent = true }
-
-    keymap("n", "<leader>rh", "<cmd>RustSetInlayHints<Cr>", key_opts)
-    keymap("n", "<leader>rhd", "<cmd>RustDisableInlayHints<Cr>", key_opts)
-    keymap("n", "<leader>th", "<cmd>RustToggleInlayHints<Cr>", key_opts)
-    keymap("n", "<leader>rr", "<cmd>RustRunnables<Cr>", key_opts)
-    keymap("n", "<leader>rem", "<cmd>RustExpandMacro<Cr>", key_opts)
-    keymap("n", "<leader>roc", "<cmd>RustOpenCargo<Cr>", key_opts)
-    keymap("n", "<leader>rpm", "<cmd>RustParentModule<Cr>", key_opts)
-    keymap("n", "<leader>rjl", "<cmd>RustJoinLines<Cr>", key_opts)
-    keymap("n", "<leader>rha", "<cmd>RustHoverActions<Cr>", key_opts)
-    keymap("n", "<leader>rhr", "<cmd>RustHoverRange<Cr>", key_opts)
-    keymap("n", "<leader>rmd", "<cmd>RustMoveItemDown<Cr>", key_opts)
-    keymap("n", "<leader>rmu", "<cmd>RustMoveItemUp<Cr>", key_opts)
-    keymap("n", "<leader>rsb", "<cmd>RustStartStandaloneServerForBuffer<Cr>", key_opts)
-    keymap("n", "<leader>rd", "<cmd>RustDebuggables<Cr>", key_opts)
-    keymap("n", "<leader>rv", "<cmd>RustViewCrateGraph<Cr>", key_opts)
-    keymap("n", "<leader>rw", "<cmd>RustReloadWorkspace<Cr>", key_opts)
-    keymap("n", "<leader>rss", "<cmd>RustSSR<Cr>", key_opts)
-    keymap("n", "<leader>rxd", "<cmd>RustOpenExternalDocs<Cr>", key_opts)
-
     require("rust-tools").setup {
       tools = {
         on_initialized = function()


### PR DESCRIPTION
In `lsp-installer.lua` the language servers are being setup by looping through an array of server names rather than the deprecated `on_server_ready` event. As a result, each server is setup at start-time. This means that the rust specific keybindings are set for all filetypes rather than for just rust specifically.

I moved the keymaps into their own rust specific ftplugin file to ensure that they are only set for rust files.