### PR TITLE
check for jsx/tsx filetypes before loading hooks

### DIFF
--- a/lua/user/comment.lua
+++ b/lua/user/comment.lua
@@ -5,18 +5,20 @@ end
 
 comment.setup {
   pre_hook = function(ctx)
-    local U = require "Comment.utils"
+    if vim.bo.filetype == 'typescriptreact' then
+      local U = require "Comment.utils"
 
-    local location = nil
-    if ctx.ctype == U.ctype.block then
-      location = require("ts_context_commentstring.utils").get_cursor_location()
-    elseif ctx.cmotion == U.cmotion.v or ctx.cmotion == U.cmotion.V then
-      location = require("ts_context_commentstring.utils").get_visual_start_location()
+      local location = nil
+      if ctx.ctype == U.ctype.block then
+        location = require("ts_context_commentstring.utils").get_cursor_location()
+      elseif ctx.cmotion == U.cmotion.v or ctx.cmotion == U.cmotion.V then
+        location = require("ts_context_commentstring.utils").get_visual_start_location()
+      end
+
+      return require("ts_context_commentstring.internal").calculate_commentstring {
+        key = ctx.ctype == U.ctype.line and "__default" or "__multiline",
+        location = location,
+      }
     end
-
-    return require("ts_context_commentstring.internal").calculate_commentstring {
-      key = ctx.ctype == U.ctype.line and "__default" or "__multiline",
-      location = location,
-    }
   end,
 }


### PR DESCRIPTION
Loading the hooks for all filetypes causes all comments to be applied as block comments, whereas by default, doing `gcc` should result in line comments as per `Comment.nvim` docs.

This PR checks for the filetypes to be jsx/tsx before loading the hooks.