### PR TITLE
Map window resize to the left to left arrow key

### DIFF
--- a/lua/user/keymaps.lua
+++ b/lua/user/keymaps.lua
@@ -25,8 +25,8 @@ keymap("n", "<C-l>", "<C-w>l", opts)
 -- Resize with arrows
 keymap("n", "<C-Up>", ":resize -2<CR>", opts)
 keymap("n", "<C-Down>", ":resize +2<CR>", opts)
-keymap("n", "<C-Left>", ":vertical resize -2<CR>", opts)
-keymap("n", "<C-Right>", ":vertical resize +2<CR>", opts)
+keymap("n", "<C-Right>", ":vertical resize -2<CR>", opts)
+keymap("n", "<C-Left>", ":vertical resize +2<CR>", opts)
 
 -- Navigate buffers
 keymap("n", "<S-l>", ":bnext<CR>", opts)


### PR DESCRIPTION
Before: resizing with C-Left resized the current window to the right and vice versa
Fixed the mapping for the orientation

It appears only I have this flipped behavior... Feel free to comment or decline changes
