### PR TITLE
Update deprecated api for Comment.nvim

### DIFF
--- a/lua/user/keymaps.lua
+++ b/lua/user/keymaps.lua
@@ -65,8 +65,8 @@ keymap("n", "<leader>fb", ":Telescope buffers<CR>", opts)
 keymap("n", "<leader>gg", "<cmd>lua _LAZYGIT_TOGGLE()<CR>", opts)
 
 -- Comment
-keymap("n", "<leader>/", "<cmd>lua require('Comment.api').toggle_current_linewise()<CR>", opts)
-keymap("x", "<leader>/", '<ESC><CMD>lua require("Comment.api").toggle_linewise_op(vim.fn.visualmode())<CR>')
+keymap("n", "<leader>/", "<cmd>lua require('Comment.api').toggle.linewise.current()<CR>", opts)
+keymap("x", "<leader>/", '<ESC><CMD>lua require("Comment.api").toggle.linewise(vim.fn.visualmode())<CR>')
 
 -- DAP
 keymap("n", "<leader>db", "<cmd>lua require'dap'.toggle_breakpoint()<cr>", opts)


### PR DESCRIPTION
- More information in this [discussion ](https://github.com/numToStr/Comment.nvim/discussions/233)
- Current [pinned version](https://github.com/numToStr/Comment.nvim/blob/97a188a98b5a3a6f9b1b850799ac078faa17ab67/lua/Comment/api.lua) installs already new api