### PR TITLE
Fix(Floating window): words breaking halfway

### DIFF
--- a/lua/user/options.lua
+++ b/lua/user/options.lua
@@ -39,3 +39,4 @@ vim.opt.shortmess:append "c"                    -- hide all the completion messa
 vim.opt.whichwrap:append("<,>,[,],h,l")         -- keys allowed to move to the previous/next line when the beginning/end of line is reached
 vim.opt.iskeyword:append("-")                   -- treats words with `-` as single words
 vim.opt.formatoptions:remove({ "c", "r", "o" }) -- This is a sequence of letters which describes how automatic formatting is to be done
+vim.opt.linebreak = true


### PR DESCRIPTION
Working with multiple windows tends to make words in floating windows, like the diagnostics, break halfway. In my experience, it is not readable and not a good experience to deal with. That is why I propose adding `vim.opt.linebreak = true` in `options.lua` to solve this problem.

Before:
![Screenshot from 2022-11-08 21-13-16](https://user-images.githubusercontent.com/74945153/200574110-c5da6d81-8d4a-47c5-9353-46a55eab5c9d.png)

After:
![Screenshot from 2022-11-08 21-14-19](https://user-images.githubusercontent.com/74945153/200574129-f28003ff-348d-4d1e-b945-7c78f2b297c4.png)
