### PR TITLE
chore(plugin): update mason-lspconfig plugin

### DIFF
--- a/lua/user/plugins.lua
+++ b/lua/user/plugins.lua
@@ -80,7 +80,7 @@ return packer.startup(function(use)
   -- use { "williamboman/nvim-lsp-installer", commit = "e9f13d7acaa60aff91c58b923002228668c8c9e6" } -- simple to use language server installer
   use { "neovim/nvim-lspconfig", commit = "f11fdff7e8b5b415e5ef1837bdcdd37ea6764dda" } -- enable LSP
   use { "williamboman/mason.nvim", commit = "c2002d7a6b5a72ba02388548cfaf420b864fbc12"}
-  use { "williamboman/mason-lspconfig.nvim", commit = "0051870dd728f4988110a1b2d47f4a4510213e31" }
+  use { "williamboman/mason-lspconfig.nvim", commit = "0eb7cfefbd3a87308c1875c05c3f3abac22d367c" }
   use { "jose-elias-alvarez/null-ls.nvim", commit = "c0c19f32b614b3921e17886c541c13a72748d450" } -- for formatters and linters
   use { "RRethy/vim-illuminate", commit = "a2e8476af3f3e993bb0d6477438aad3096512e42" }
 


### PR DESCRIPTION
**Issue**: Volar lsp-client wasn't showing or attaching to the buffer. Also getting the following error after opening vue files.

![](https://user-images.githubusercontent.com/51720003/194781501-2d45e49c-0948-4e4d-896c-072a35c9a344.png)


**Solution**: 
Fixed in https://github.com/williamboman/mason-lspconfig.nvim/commit/0eb7cfefbd3a87308c1875c05c3f3abac22d367c
Update the mason-lspconfig plugin commit in plugins.lua to this or higher commit. Also, add "Volar" to the ensure_installed list of lsp_servers.
Like this,
```lua
require("mason-lspconfig").setup({
    ensure_installed = { "sumneko_lua", "volar" }
})
```



### Screenshot: Volar not attaching to the buffer.

![image](https://user-images.githubusercontent.com/66965591/202438336-3f0f9ff8-df31-4f09-8da6-5fea2e06146b.png)
