### PR TITLE
Bdelete command isn't available when certain

### DIFF
--- a/lua/user/bufferline.lua
+++ b/lua/user/bufferline.lua
@@ -5,8 +5,8 @@ end
 
 bufferline.setup {
   options = {
-    close_command = "Bdelete! %d", -- can be a string | function, see "Mouse actions"
-    right_mouse_command = "Bdelete! %d", -- can be a string | function, see "Mouse actions"
+    close_command = "bdelete! %d", -- can be a string | function, see "Mouse actions"
+    right_mouse_command = "bdelete! %d", -- can be a string | function, see "Mouse actions"
     offsets = { { filetype = "NvimTree", text = "", padding = 1 } },
     separator_style = "thin", -- | "thick" | "thin" | { 'any', 'any' },
   },


### PR DESCRIPTION
plugins aren't installed yet throwing error on first startup. This keeps functionality and avoids the error. Not sure which plugin makes Bdelete! a usable command(guessing bufferline?), but it isn't available on first startup