### PR TITLE
nvim tree updates

### DIFF
--- a/lua/user/nvim-tree.lua
+++ b/lua/user/nvim-tree.lua
@@ -13,7 +13,6 @@ local tree_cb = nvim_tree_config.nvim_tree_callback
 nvim_tree.setup {
   update_focused_file = {
     enable = true,
-    update_cwd = true,
   },
   renderer = {
     root_folder_modifier = ":t",


### PR DESCRIPTION
Stops nvim-tree from showing files all the way to home directory when opening a file.  with newest version of nvim-tree***
`
nvim-tree.update_focused_file.update_root*  (previously update_focused_file.update_cwd) `
value defaults to false, which fixes the bug of showing files to home directory