### PR TITLE
Update nvim-web-devicons repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ Just make a new file with your plugin and the configuration in it,
 - [nvim-autopairs](https://github.com/windwp/nvim-autopairs)
 - [Comment.nvim](https://github.com/numToStr/Comment.nvim)
 - [nvim-ts-context-commentstring](https://github.com/JoosepAlviste/nvim-ts-context-commentstring)
-- [nvim-web-devicons](https://github.com/kyazdani42/nvim-web-devicons)
+- [nvim-web-devicons](https://github.com/nvim-tree/nvim-web-devicons)
 - [nvim-tree.lua](https://github.com/kyazdani42/nvim-tree.lua)
 - [bufferline.nvim](https://github.com/akinsho/bufferline.nvim)
 - [bufdelete.nvim](https://github.com/famiu/bufdelete.nvim)

--- a/lua/user/nvim-dev-icons.lua
+++ b/lua/user/nvim-dev-icons.lua
@@ -1,7 +1,7 @@
 local M = {
   "nvim-tree/nvim-web-devicons",
   event = "VeryLazy",
-  commit = "95b1e300699be8eb6b5be1758a9d4d69fe93cc7f"
+  commit = "0568104bf8d0c3ab16395433fcc5c1638efc25d4"
 }
 
 function M.config()

--- a/lua/user/nvim-dev-icons.lua
+++ b/lua/user/nvim-dev-icons.lua
@@ -1,5 +1,5 @@
 local M = {
-  "kyazdani42/nvim-web-devicons",
+  "nvim-tree/nvim-web-devicons",
   event = "VeryLazy",
   commit = "95b1e300699be8eb6b5be1758a9d4d69fe93cc7f"
 }

--- a/lua/user/treesitter.lua
+++ b/lua/user/treesitter.lua
@@ -9,7 +9,7 @@ local M = {
       commit = "729d83ecb990dc2b30272833c213cc6d49ed5214",
     },
     {
-      "kyazdani42/nvim-web-devicons",
+      "nvim-tree/nvim-web-devicons",
       event = "VeryLazy",
       commit = "0568104bf8d0c3ab16395433fcc5c1638efc25d4"
     },


### PR DESCRIPTION
## Update repository 

`kyazdani42/nvim-web-devicons` was moved to `nvim-tree/nvim-web-devicons`.

## Update nvim-dev-icons commit hash

Update to commit hash defined in `treesitter.lua` and `lazy-lock.json`.
Fixes `:checkhealth` lazy.nvim WARNING:
`{nvim-ts-context-commentstring}: overriding <commit>`