### PR TITLE
simplify paste keybind

### DIFF
--- a/lua/keymaps.lua
+++ b/lua/keymaps.lua
@@ -39,7 +39,7 @@ keymap("n", "<leader>h", "<cmd>nohlsearch<CR>", opts)
 keymap("n", "<S-q>", "<cmd>Bdelete!<CR>", opts)
 
 -- Better paste
-keymap("v", "p", '"_dP', opts)
+keymap("v", "p", 'P', opts)
 
 -- Insert --
 -- Press jk fast to enter


### PR DESCRIPTION
`"_dP` does the same as just `P` in visual mode, and is less confusing to the reader