### PR TITLE
Update nvim-ts-context-commentstring dependency commit in comment.lua

### DIFF
--- a/lua/user/comment.lua
+++ b/lua/user/comment.lua
@@ -6,7 +6,7 @@ local M = {
     {
       "JoosepAlviste/nvim-ts-context-commentstring",
       event = "VeryLazy",
-      commit = "a0f89563ba36b3bacd62cf967b46beb4c2c29e52",
+      commit = "729d83ecb990dc2b30272833c213cc6d49ed5214",
     },
   },
 }


### PR DESCRIPTION
Commit specified for nvim-ts-context-commentstring dependency in comment.lua is now the same as the one specified in treesitter.lua.

This clears the warning:

`WARNING {nvim-ts-context-commentstring}: overriding <commit>`

when doing a `:checkhealth lazy`.