### PR TITLE
fix(bufferline): E5248: Invalid character in group name nvim

### DIFF
--- a/lua/user/bufferline.lua
+++ b/lua/user/bufferline.lua
@@ -19,7 +19,7 @@ function M.config()
     },
     highlights = {
       fill = {
-        fg = { attribute = "fg", highlight = "#ff0000" },
+        fg = { attribute = "fg", highlight = "TabLine" },
         bg = { attribute = "bg", highlight = "TabLine" },
       },
       background = {


### PR DESCRIPTION
## Description

Fixes [akinsho/bufferline.nvim](https://github.com/akinsho/bufferline.nvim) E5248 error for[v4.1.0](https://github.com/akinsho/bufferline.nvim/releases/tag/v4.1.0) (currently not used, causes error when upgraded).

## Reproduce

Environment:

```shell
akinsho/bufferline.nvim v4.1.0
NVIM v0.9.0
Build type: Release
LuaJIT 2.1.0-beta3
```

Edit any file.

## Issue

[issues/724](https://github.com/akinsho/bufferline.nvim/issues/724#issuecomment-1501182972)