### PR TITLE
fix: defer cmp_nvim_lsp require to config

### DIFF
--- a/lua/user/lsp.lua
+++ b/lua/user/lsp.lua
@@ -10,8 +10,9 @@ local M = {
   },
 }
 
-local cmp_nvim_lsp = require "cmp_nvim_lsp"
 function M.config()
+  local cmp_nvim_lsp = require "cmp_nvim_lsp"
+
   local capabilities = vim.lsp.protocol.make_client_capabilities()
   capabilities.textDocument.completion.completionItem.snippetSupport = true
   capabilities = cmp_nvim_lsp.default_capabilities(M.capabilities)


### PR DESCRIPTION
If cmp_nvim_lsp has not already been installed, this require will fail. Moving it to the config call allows lazy to find it listed in the dependencies above and install it _before_ we try requiring it.

I suspect this doesn't happen if you start from the full `nvim-basic-ide` example since it'll also get installed in `cmp.lua` but I was building my config up step-by-step with this as a guide and bumped into it.