### PR TITLE
Lazy loading fix for Comment.nvim

### DIFF
--- a/lua/user/comment.lua
+++ b/lua/user/comment.lua
@@ -1,7 +1,7 @@
 local M = {
   "numToStr/Comment.nvim",
   commit = "eab2c83a0207369900e92783f56990808082eac2",
-  event = "BufRead",
+  event = {"BufRead", "BufNewFile"},
   dependencies = {
     {
       "JoosepAlviste/nvim-ts-context-commentstring",


### PR DESCRIPTION
If you create a new file from the terminal like this: `nvim randomNewFile.md`, it won't lazy load Comment.nvim, unless you type `:edit` again. 