### PR TITLE
fix lsp not working for new python files

### DIFF
--- a/lua/user/autopairs.lua
+++ b/lua/user/autopairs.lua
@@ -5,7 +5,6 @@ local M = {
   dependencies = {
     {
       "hrsh7th/nvim-cmp",
-      commit = "cfafe0a1ca8933f7b7968a287d39904156f2c57d",
       event = {
         "InsertEnter",
         "CmdlineEnter",

--- a/lua/user/dap.lua
+++ b/lua/user/dap.lua
@@ -57,7 +57,6 @@ end
 M = {
   "ravenxrz/DAPInstall.nvim",
   commit = "8798b4c36d33723e7bba6ed6e2c202f84bb300de",
-  lazy = true,
   config = function()
     require("dap_install").setup {}
     require("dap_install").config("python", {})

--- a/lua/user/dapui.lua
+++ b/lua/user/dapui.lua
@@ -5,7 +5,6 @@ local M = {
   dependencies = {
     {
       "mfussenegger/nvim-dap",
-      commit = "6b12294a57001d994022df8acbe2ef7327d30587",
       event = "VeryLazy",
     },
   },

--- a/lua/user/lsp.lua
+++ b/lua/user/lsp.lua
@@ -1,7 +1,8 @@
 local M = {
   "neovim/nvim-lspconfig",
   commit = "649137cbc53a044bffde36294ce3160cb18f32c7",
-  lazy = true,
+  lazy = false,
+  event = { BufReadPre },
   dependencies = {
     {
       "hrsh7th/cmp-nvim-lsp",

--- a/lua/user/mason.lua
+++ b/lua/user/mason.lua
@@ -7,7 +7,6 @@ local M = {
     {
       "williamboman/mason-lspconfig.nvim",
       commit = "93e58e100f37ef4fb0f897deeed20599dae9d128",
-      lazy = true,
     },
   },
 }

--- a/lua/user/null-ls.lua
+++ b/lua/user/null-ls.lua
@@ -6,7 +6,6 @@ local M = {
     {
       "nvim-lua/plenary.nvim",
       commit = "9a0d3bf7b832818c042aaf30f692b081ddd58bd9",
-      lazy = true,
     },
   },
 }

--- a/lua/user/project.lua
+++ b/lua/user/project.lua
@@ -4,7 +4,6 @@ local M = {
   dependencies = {
     {
       "nvim-telescope/telescope.nvim",
-      commit = "203bf5609137600d73e8ed82703d6b0e320a5f36",
       event = "Bufenter",
       cmd = { "Telescope" },
     },

--- a/lua/user/telescope.lua
+++ b/lua/user/telescope.lua
@@ -6,7 +6,6 @@ local M = {
   dependencies = {
     {
       "ahmedkhalf/project.nvim",
-      commit = "8c6bad7d22eef1b71144b401c9f74ed01526a4fb",
     },
   },
 }

--- a/lua/user/treesitter.lua
+++ b/lua/user/treesitter.lua
@@ -11,7 +11,6 @@ local M = {
     {
       "nvim-tree/nvim-web-devicons",
       event = "VeryLazy",
-      commit = "0568104bf8d0c3ab16395433fcc5c1638efc25d4"
     },
   },
 }


### PR DESCRIPTION
- fix issue #143 
- remove conflicting dependencies (where we causing warnings)
- `lazy = true` is default, no need to write it explicitly