### PR TITLE
fix(lsp): surround event name if double quotes

### DIFF
--- a/lua/user/lsp.lua
+++ b/lua/user/lsp.lua
@@ -2,7 +2,7 @@ local M = {
   "neovim/nvim-lspconfig",
   commit = "649137cbc53a044bffde36294ce3160cb18f32c7",
   lazy = false,
-  event = { BufReadPre },
+  event = { "BufReadPre" },
   dependencies = {
     {
       "hrsh7th/cmp-nvim-lsp",


### PR DESCRIPTION
surround event name if double quotes