### PR TITLE
Fix lsp event BufReadPre

### DIFF
--- a/lua/user/lsp.lua
+++ b/lua/user/lsp.lua
@@ -2,7 +2,7 @@ local M = {
   "neovim/nvim-lspconfig",
   commit = "649137cbc53a044bffde36294ce3160cb18f32c7",
   lazy = false,
-  event = { BufReadPre },
+  event = "BufReadPre",
   dependencies = {
     {
       "hrsh7th/cmp-nvim-lsp",


### PR DESCRIPTION
Fixes event value to use string literal
and not rely on global var.