### PR TITLE
fix illuminate options not work

### DIFF
--- a/lua/user/illuminate.lua
+++ b/lua/user/illuminate.lua
@@ -6,20 +6,6 @@ local M = {
 
 function M.config()
   local illuminate = require "illuminate"
-  vim.g.Illuminate_ftblacklist = { "alpha", "NvimTree" }
-  vim.api.nvim_set_keymap(
-    "n",
-    "<a-n>",
-    '<cmd>lua require"illuminate".next_reference{wrap=true}<cr>',
-    { noremap = true }
-  )
-  vim.api.nvim_set_keymap(
-    "n",
-    "<a-p>",
-    '<cmd>lua require"illuminate".next_reference{reverse=true,wrap=true}<cr>',
-    { noremap = true }
-  )
-
   illuminate.configure {
     providers = {
       "lsp",


### PR DESCRIPTION
g.Illuminate_ftblacklist like configuration was deprecated, keymaps was already set by default.